### PR TITLE
Change interface to support rule metas

### DIFF
--- a/lib/yara.rb
+++ b/lib/yara.rb
@@ -5,7 +5,6 @@ require "pry"
 require_relative "yara/version"
 require_relative "yara/ffi"
 
-# TBD
 module Yara
   class Error < StandardError; end
 
@@ -17,7 +16,6 @@ module Yara
 
   def self.test(rule_string, test_string)
     user_data = UserData.new
-    user_data[:number] = 42
     scanning = true
     results = []
 

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -2,7 +2,6 @@ module Yara
   class ScanResult
     RULE_MATCHING     = 1
     RULE_NOT_MATCHING = 2
-    SCAN_FINISHED     = 3
 
     META_FLAGS_LAST_IN_RULE = 1
 

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -4,7 +4,14 @@ module Yara
     RULE_NOT_MATCHING = 2
     SCAN_FINISHED     = 3
 
-    RULE_IDENTIFIER = 1
+    META_FLAGS_LAST_IN_RULE = 1
+
+    META_TYPE_INTEGER = 1
+    META_TYPE_STRING  = 2
+    META_TYPE_BOOLEAN = 3
+
+    RULE_IDENTIFIER  = 1
+    METAS_IDENTIFIER = 3
 
     attr_reader :callback_type, :rule
 
@@ -17,6 +24,24 @@ module Yara
       @rule.values[RULE_IDENTIFIER]
     end
 
+    def rule_meta
+      metas = {}
+      reading_metas = true
+      meta_index = 0
+      meta_pointer = @rule.values[METAS_IDENTIFIER]
+      while reading_metas do
+        meta = YrMeta.new(meta_pointer + meta_index * YrMeta.size)
+        metas.merge!(meta_as_hash(meta))
+        flags = meta.values.last
+        if flags == META_FLAGS_LAST_IN_RULE
+          reading_metas = false
+        else
+          meta_index += 1
+        end
+      end
+      metas
+    end
+
     def scan_complete?
       callback_type == SCAN_FINISHED
     end
@@ -27,6 +52,24 @@ module Yara
 
     def match?
       callback_type == RULE_MATCHING
+    end
+
+    private
+
+    def meta_as_hash(meta)
+      name, string_value, int_value, type, _flags = meta.values
+      value = meta_value(string_value, int_value, type)
+      { name.to_sym => value }
+    end
+
+    def meta_value(string_value, int_value, type)
+      if type == META_TYPE_INTEGER
+        int_value
+      elsif type == META_TYPE_BOOLEAN
+        int_value == 1
+      else
+        string_value
+      end
     end
   end
 end

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -1,0 +1,32 @@
+module Yara
+  class ScanResult
+    RULE_MATCHING     = 1
+    RULE_NOT_MATCHING = 2
+    SCAN_FINISHED     = 3
+
+    RULE_IDENTIFIER = 1
+
+    attr_reader :callback_type, :rule
+
+    def initialize(callback_type, rule_ptr)
+      @callback_type = callback_type
+      @rule = YrRule.new(rule_ptr)
+    end
+
+    def rule_name
+      @rule.values[RULE_IDENTIFIER]
+    end
+
+    def scan_complete?
+      callback_type == SCAN_FINISHED
+    end
+
+    def rule_outcome?
+      [RULE_MATCHING, RULE_NOT_MATCHING].include?(callback_type)
+    end
+
+    def match?
+      callback_type == RULE_MATCHING
+    end
+  end
+end

--- a/lib/yara/version.rb
+++ b/lib/yara/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Yara
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/lib/yara/yr_meta.rb
+++ b/lib/yara/yr_meta.rb
@@ -2,6 +2,9 @@ module Yara
   class YrMeta < FFI::Struct
     layout \
       :identifier, :string,
-      :type, :int32_t
+      :string, :string,
+      :integer, :int64_t,
+      :type, :int32_t,
+      :flags, :int32_t
   end
 end

--- a/lib/yara/yr_rule.rb
+++ b/lib/yara/yr_rule.rb
@@ -4,7 +4,7 @@ module Yara
       :flags, :int32_t,
       :identifier, :string,
       :tags, :string,
-      :metas, YrMeta.ptr,
+      :metas, :pointer,
       :strings, YrString.ptr,
       :ns, YrNamespace.ptr
   end

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -21,12 +21,12 @@ class YaraTest < Minitest::Test
   end
 
   def test_rule_that_matches
-    expected_results = ["ExampleRule"]
-    assert_equal expected_results, Yara.test(rule, "i think we were here that one time")
+    result = Yara.test(rule, "i think we were here that one time").first
+    assert result.match?
   end
 
   def test_rule_that_does_not_match
-    expected_results = []
-    assert_equal expected_results, Yara.test(rule, "we were never here i'm pretty sure")
+    result = Yara.test(rule, "we were never here i'm pretty sure").first
+    refute result.match?
   end
 end

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -11,6 +11,12 @@ class YaraTest < Minitest::Test
     <<-RULE
       rule ExampleRule
       {
+        meta:
+          string_meta = "an example rule for testing"
+          false_meta = false
+          true_meta = true
+          int_meta = 123
+
         strings:
           $my_text_string = "we were here"
 
@@ -28,5 +34,16 @@ class YaraTest < Minitest::Test
   def test_rule_that_does_not_match
     result = Yara.test(rule, "we were never here i'm pretty sure").first
     refute result.match?
+  end
+
+  def test_rule_meta_parsing
+    result = Yara.test(rule, "i think we were here that one time").first
+    expected_meta = {
+      string_meta: "an example rule for testing",
+      false_meta: false,
+      true_meta: true,
+      int_meta: 123
+    }
+    assert_equal expected_meta, result.rule_meta
   end
 end


### PR DESCRIPTION
## Why?

Currently `Yara.test` returns an array of the rule names that matched the given string. This does not allow us to know a rule's metas or strings values. This PR changes this method to return an array of `Yara::ScanResult` objects, which have methods to know the rule's name, if it matched, and any metas.

## How?

- Return a Yara::ScanResult object instead of only rule name
- Return rule metas as a hash of name => value
