### PR TITLE
Use a pointer to the test string to allow for null bytes

### DIFF
--- a/lib/yara.rb
+++ b/lib/yara.rb
@@ -44,10 +44,14 @@ module Yara
       0 # ERROR_SUCCESS
     end
 
+    test_string_bytesize = test_string.bytesize
+    test_string_pointer = ::FFI::MemoryPointer.new(:char, test_string_bytesize)
+    test_string_pointer.put_bytes(0, test_string)
+
     Yara::FFI.yr_rules_scan_mem(
       rules_pointer,
-      test_string,
-      test_string.bytesize,
+      test_string_pointer,
+      test_string_bytesize,
       0,
       result_callback,
       user_data,

--- a/lib/yara/ffi.rb
+++ b/lib/yara/ffi.rb
@@ -100,7 +100,7 @@ module Yara
     #   int timeout)
     attach_function :yr_rules_scan_mem, [
       :pointer,       # rules_pointer*
-      :string,        # buffer (aka test subject)
+      :pointer,       # buffer (aka test subject)
       :size_t,        # buffer size (String#bytesize)
       :int,           # flags
       :scan_callback, # proc

--- a/lib/yara/version.rb
+++ b/lib/yara/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Yara
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -46,4 +46,9 @@ class YaraTest < Minitest::Test
     }
     assert_equal expected_meta, result.rule_meta
   end
+
+  def test_string_with_null_byte
+    result = Yara.test(rule, "hi\000").first
+    refute result.match?
+  end
 end


### PR DESCRIPTION
## Why?

This allows Ruby strings with null bytes to be scanned by Yara

## How?

Instead of passing the Ruby string directly, we create a memory pointer and put the string in it and then pass that to Yara.
