### PR TITLE
Add ScanResult#rule_strings method

### DIFF
--- a/lib/yara/version.rb
+++ b/lib/yara/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Yara
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/lib/yara/yr_rule.rb
+++ b/lib/yara/yr_rule.rb
@@ -5,7 +5,7 @@ module Yara
       :identifier, :string,
       :tags, :string,
       :metas, :pointer,
-      :strings, YrString.ptr,
+      :strings, :pointer,
       :ns, YrNamespace.ptr
   end
 end

--- a/lib/yara/yr_string.rb
+++ b/lib/yara/yr_string.rb
@@ -1,5 +1,15 @@
 module Yara
   class YrString < FFI::Struct
-    layout :identifier, :string
+    layout \
+      :flags, :uint32_t,
+      :idx, :uint32_t,
+      :fixed_offset, :int64_t,
+      :rule_idx, :uint32_t,
+      :length, :int32_t,
+      :string, :pointer,
+      :chained_to, :pointer,
+      :chain_gap_min, :int32_t,
+      :chain_gap_max, :int32_t,
+      :identifier, :string
   end
 end

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -19,9 +19,10 @@ class YaraTest < Minitest::Test
 
         strings:
           $my_text_string = "we were here"
+          $my_text_regex = /were here/
 
         condition:
-          $my_text_string
+          $my_text_string or $my_text_regex
       }
     RULE
   end
@@ -45,6 +46,15 @@ class YaraTest < Minitest::Test
       int_meta: 123
     }
     assert_equal expected_meta, result.rule_meta
+  end
+
+  def test_rule_string_parsing
+    result = Yara.test(rule, "i think we were here that one time").first
+    expected_strings = {
+      "$my_text_string": "we were here",
+      "$my_text_regex": "were here",
+    }
+    assert_equal expected_strings, result.rule_strings
   end
 
   def test_string_with_null_byte


### PR DESCRIPTION
## Why?

Sometimes we want to know the exact string that matched a rule.

## How?

We have added `ScanResult#rule_strings` which returns the strings as a hash of form `string identifier => value`.
