### PR TITLE
Capture meta and strings on new scan result

### DIFF
--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -14,10 +14,6 @@ module Yara
     STRING_LENGTH = 4
     STRING_POINTER = 5
 
-    RULE_IDENTIFIER  = 1
-    METAS_IDENTIFIER = 3
-    STRING_IDENTIFIER = 4
-
     attr_reader :callback_type, :rule
 
     def initialize(callback_type, rule_ptr)
@@ -30,7 +26,7 @@ module Yara
     attr_reader :rule_meta, :rule_strings
 
     def rule_name
-      @rule.values[RULE_IDENTIFIER]
+      @rule[:identifier]
     end
 
     def scan_complete?
@@ -51,7 +47,7 @@ module Yara
       metas = {}
       reading_metas = true
       meta_index = 0
-      meta_pointer = @rule.values[METAS_IDENTIFIER]
+      meta_pointer = @rule[:metas]
       while reading_metas do
         meta = YrMeta.new(meta_pointer + meta_index * YrMeta.size)
         metas.merge!(meta_as_hash(meta))
@@ -69,7 +65,7 @@ module Yara
       strings = {}
       reading_strings = true
       string_index = 0
-      string_pointer = @rule.values[STRING_IDENTIFIER]
+      string_pointer = @rule[:strings]
       while reading_strings do
         string = YrString.new(string_pointer + string_index * YrString.size)
         string_length = string.values[STRING_LENGTH]

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -23,13 +23,31 @@ module Yara
     def initialize(callback_type, rule_ptr)
       @callback_type = callback_type
       @rule = YrRule.new(rule_ptr)
+      @rule_meta = extract_rule_meta
+      @rule_strings = extract_rule_strings
     end
+
+    attr_reader :rule_meta, :rule_strings
 
     def rule_name
       @rule.values[RULE_IDENTIFIER]
     end
 
-    def rule_meta
+    def scan_complete?
+      callback_type == SCAN_FINISHED
+    end
+
+    def rule_outcome?
+      [RULE_MATCHING, RULE_NOT_MATCHING].include?(callback_type)
+    end
+
+    def match?
+      callback_type == RULE_MATCHING
+    end
+
+    private
+
+    def extract_rule_meta
       metas = {}
       reading_metas = true
       meta_index = 0
@@ -47,7 +65,7 @@ module Yara
       metas
     end
 
-    def rule_strings
+    def extract_rule_strings
       strings = {}
       reading_strings = true
       string_index = 0
@@ -65,20 +83,6 @@ module Yara
       end
       strings
     end
-
-    def scan_complete?
-      callback_type == SCAN_FINISHED
-    end
-
-    def rule_outcome?
-      [RULE_MATCHING, RULE_NOT_MATCHING].include?(callback_type)
-    end
-
-    def match?
-      callback_type == RULE_MATCHING
-    end
-
-    private
 
     def meta_as_hash(meta)
       name, string_value, int_value, type, _flags = meta.values


### PR DESCRIPTION
## Why?

We noticed when we tried to dockerize that tests started failing with memory errors and we couldn't consistently get to a `binding.pry`. This was happening because we were trying to access things in memory after they had potentially been garbage collected, causing indeterminate behavior.

## How?

As soon as we build a `ScanResult` we capture the values for `metas` and `strings`.

:pear: with @kmcq