### PR TITLE
Use struct hash access and Struct.ptr where possible

### DIFF
--- a/lib/yara.rb
+++ b/lib/yara.rb
@@ -13,6 +13,7 @@ module Yara
 
   def self.test(rule_string, test_string)
     user_data = UserData.new
+    user_data[:number] = 42
     scanning = true
     results = []
 
@@ -33,11 +34,11 @@ module Yara
     Yara::FFI.yr_compiler_get_rules(compiler_pointer, rules_pointer)
     rules_pointer = rules_pointer.get_pointer(0)
 
-    result_callback = proc do |context_ptr, callback_type, rule_ptr, user_data_ptr|
+    result_callback = proc do |context_ptr, callback_type, rule, user_data|
       if callback_type == SCAN_FINISHED
         scanning = false
       else
-        result = ScanResult.new(callback_type, rule_ptr)
+        result = ScanResult.new(callback_type, rule, user_data)
         results << result if result.rule_outcome?
       end
 

--- a/lib/yara/ffi.rb
+++ b/lib/yara/ffi.rb
@@ -90,9 +90,9 @@ module Yara
     #   void* user_data)
     callback :scan_callback, [
       :pointer,       # YR_SCAN_CONTEXT*
-      :int,           # message
-      :pointer,       # message_data_pointer
-      :pointer,       # user_data_pointer
+      :int,           # callback_type
+      YrRule.ptr,     # rule
+      UserData.ptr,   # user_data
     ], :int
 
     # int yr_rules_scan_mem(

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -13,14 +13,15 @@ module Yara
 
     attr_reader :callback_type, :rule
 
-    def initialize(callback_type, rule_ptr)
+    def initialize(callback_type, rule, user_data)
       @callback_type = callback_type
-      @rule = YrRule.new(rule_ptr)
+      @rule = rule
       @rule_meta = extract_rule_meta
       @rule_strings = extract_rule_strings
+      @user_data_number = user_data[:number]
     end
 
-    attr_reader :rule_meta, :rule_strings
+    attr_reader :rule_meta, :rule_strings, :user_data_number
 
     def rule_name
       @rule[:identifier]

--- a/lib/yara/scan_result.rb
+++ b/lib/yara/scan_result.rb
@@ -6,13 +6,10 @@ module Yara
     META_FLAGS_LAST_IN_RULE = 1
 
     META_TYPE_INTEGER = 1
-    META_TYPE_STRING  = 2
+    # META_TYPE_STRING  = 2
     META_TYPE_BOOLEAN = 3
 
     STRING_FLAGS_LAST_IN_RULE = 0
-
-    STRING_LENGTH = 4
-    STRING_POINTER = 5
 
     attr_reader :callback_type, :rule
 
@@ -51,7 +48,7 @@ module Yara
       while reading_metas do
         meta = YrMeta.new(meta_pointer + meta_index * YrMeta.size)
         metas.merge!(meta_as_hash(meta))
-        flags = meta.values.last
+        flags = meta[:flags]
         if flags == META_FLAGS_LAST_IN_RULE
           reading_metas = false
         else
@@ -68,8 +65,8 @@ module Yara
       string_pointer = @rule[:strings]
       while reading_strings do
         string = YrString.new(string_pointer + string_index * YrString.size)
-        string_length = string.values[STRING_LENGTH]
-        flags = string.values.first
+        string_length = string[:length]
+        flags = string[:flags]
         if flags == STRING_FLAGS_LAST_IN_RULE
           reading_strings = false
         else
@@ -81,14 +78,13 @@ module Yara
     end
 
     def meta_as_hash(meta)
-      name, string_value, int_value, type, _flags = meta.values
-      value = meta_value(string_value, int_value, type)
-      { name.to_sym => value }
+      value = meta_value(meta[:string], meta[:integer], meta[:type])
+      { meta[:identifier].to_sym => value }
     end
 
     def string_as_hash(yr_string)
-      string_pointer = yr_string.values[STRING_POINTER]
-      string_identifier = yr_string.values.last
+      string_pointer = yr_string[:string]
+      string_identifier = yr_string[:identifier]
       { string_identifier.to_sym => string_pointer.read_string }
     end
 

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -61,4 +61,9 @@ class YaraTest < Minitest::Test
     result = Yara.test(rule, "hi\000").first
     refute result.match?
   end
+
+  def test_user_data
+    result = Yara.test(rule, "i think we were here that one time").first
+    assert_equal 42, result.user_data_number
+  end
 end


### PR DESCRIPTION
## Why?

- Struct hash access makes it easier to access struct members that what we were doing with `struct.values[index]`.
- Defining structs and signatures using `Struct.ptr` saves time vs initializing each Struct with a pointer.