### PR TITLE
Add Yara::Scanner API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,34 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```ruby
+Yara.start # run before you start using the Yara API.
+
+rule = <<-RULE
+rule ExampleRule
+{
+meta:
+    string_meta = "an example rule for testing"
+
+strings:
+    $my_text_string = "we were here"
+    $my_text_regex = /were here/
+
+condition:
+    $my_text_string or $my_text_regex
+}
+RULE
+
+scanner = Yara::Scanner.new
+scanner.add_rule(rule)
+scanner.compile
+result = scanner.call("one day we were here and then we were not")
+result.match?
+# => true
+
+scanner.close   # run when you are done using the scanner API and want to free up memory.
+Yara.stop       # run when you are completely done using the Yara API to free up memory.
+```
 
 ## Development
 

--- a/lib/yara/scanner.rb
+++ b/lib/yara/scanner.rb
@@ -1,0 +1,81 @@
+module Yara
+  class Scanner
+    class NotCompiledError < StandardError; end
+
+    ERROR_CALLBACK = proc do |error_level, file_name, line_number, rule, message, user_data|
+      # noop
+    end
+
+    SCAN_FINISHED = 3
+
+    # Public: Initializes instance of scanner. Under the hood this calls yr_initialize, then
+    # creates a pointer, then calls yr_compiler_create with that pointer.
+    #
+    # error_callback: (optional) Proc to be called when an error occurs.
+    # user_data: (optional) Instance of UserData to store and pass information.
+    def initialize(error_callback: ERROR_CALLBACK, user_data: UserData.new)
+      @error_callback = error_callback
+      @user_data = user_data
+      @compiler_pointer = ::FFI::MemoryPointer.new(:pointer)
+      Yara::FFI.yr_compiler_create(@compiler_pointer)
+      @compiler_pointer = @compiler_pointer.get_pointer(0)
+      Yara::FFI.yr_compiler_set_callback(@compiler_pointer, error_callback, user_data)
+    end
+
+    # Public: Adds a rule to the scanner and returns the namespace value. If a namespace
+    # is not provided it will default to nil and use the global namespace.
+    #
+    # rule_string - String containing the Yara rule to be added.
+    # namespace:    (optional) String containing the namespace to be used for the rule.
+    def add_rule(rule_string, namespace: nil)
+      Yara::FFI.yr_compiler_add_string(@compiler_pointer, rule_string, namespace)
+    end
+
+    def compile
+      @rules_pointer = ::FFI::MemoryPointer.new(:pointer)
+      Yara::FFI.yr_compiler_get_rules(@compiler_pointer, @rules_pointer)
+      @rules_pointer = @rules_pointer.get_pointer(0)
+      Yara::FFI.yr_compiler_destroy(@compiler_pointer)
+    end
+
+    def call(test_string)
+      raise NotCompiledError unless @rules_pointer
+
+      results = []
+      scanning = true
+      result_callback = proc do |context_ptr, callback_type, rule, user_data|
+        if callback_type == SCAN_FINISHED
+          scanning = false
+        else
+          result = ScanResult.new(callback_type, rule, user_data)
+          results << result if result.rule_outcome?
+        end
+
+        0 # ERROR_SUCCESS
+      end
+
+      test_string_bytesize = test_string.bytesize
+      test_string_pointer = ::FFI::MemoryPointer.new(:char, test_string_bytesize)
+      test_string_pointer.put_bytes(0, test_string)
+
+      Yara::FFI.yr_rules_scan_mem(
+        @rules_pointer,
+        test_string_pointer,
+        test_string_bytesize,
+        0,
+        result_callback,
+        @user_data,
+        1,
+      )
+
+      while scanning do
+      end
+
+      results
+    end
+
+    def close
+      Yara::FFI.yr_rules_destroy(@rules_pointer)
+    end
+  end
+end

--- a/lib/yara/version.rb
+++ b/lib/yara/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Yara
-  VERSION = "2.1.1"
+  VERSION = "3.0.0"
 end

--- a/test/scanner_test.rb
+++ b/test/scanner_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ScannerTest < Minitest::Test
+  def setup
+    Yara.start
+  end
+
+  def teardown
+    Yara.stop
+  end
+
+  def rule_one
+    <<-RULE
+      rule ExampleRuleOne
+      {
+        meta:
+          description = "Example rule one"
+
+        strings:
+          $my_text_string = "one two"
+
+        condition:
+          $my_text_string
+      }
+    RULE
+  end
+
+  def rule_two
+    <<-RULE
+      rule ExampleRuleTwo
+      {
+        meta:
+          description = "Example rule two"
+
+        strings:
+          $my_text_regex = /three four/
+
+        condition:
+          $my_text_regex
+      }
+    RULE
+  end
+
+  def test_compiles_rule_and_successfully_detects_match
+    scanner = Yara::Scanner.new
+    scanner.add_rule(rule_one)
+    scanner.compile
+    results = scanner.call("one two three four")
+    assert_predicate results.first, :match?
+    scanner.close
+  end
+
+  def test_can_compile_multiple_rules_into_single_scanner
+    scanner = Yara::Scanner.new
+    scanner.add_rule(rule_one)
+    scanner.add_rule(rule_two)
+    scanner.compile
+    results = scanner.call("one two three four")
+    assert_equal [true, true], results.map(&:match?)
+    scanner.close
+  end
+
+  def test_can_compile_multiple_rules_into_separate_scanners
+    scanner1 = Yara::Scanner.new
+    scanner1.add_rule(rule_one)
+    scanner1.compile
+    scanner2 = Yara::Scanner.new
+    scanner2.add_rule(rule_two)
+    scanner2.compile
+    results1 = scanner1.call("one two three four")
+    assert_predicate results1.first, :match?
+    assert_equal 1, results1.size
+    scanner1.close
+    results2 = scanner2.call("one two three four")
+    assert_predicate results2.first, :match?
+    assert_equal 1, results2.size
+    scanner2.close
+  end
+end

--- a/test/yara_test.rb
+++ b/test/yara_test.rb
@@ -61,9 +61,4 @@ class YaraTest < Minitest::Test
     result = Yara.test(rule, "hi\000").first
     refute result.match?
   end
-
-  def test_user_data
-    result = Yara.test(rule, "i think we were here that one time").first
-    assert_equal 42, result.user_data_number
-  end
 end


### PR DESCRIPTION
## Why?

To give us more control over how we start and stop Yara and how we compile and use rules and then free up memory.

## How?

Introduced new Yara::Scanner class, moved relevant functionality there, and wrote tests.

Also bumped version to 3.0.0