### PR TITLE
Convert types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yara-ffi (2.1.1)
+    yara-ffi (3.0.0)
       ffi
 
 GEM
@@ -9,7 +9,7 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    ffi (1.15.4)
+    ffi (1.15.5)
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.20.1)
@@ -37,6 +37,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 
@@ -48,4 +49,4 @@ DEPENDENCIES
   yara-ffi!
 
 BUNDLED WITH
-   2.2.15
+   2.2.32

--- a/lib/yara/user_data.rb
+++ b/lib/yara/user_data.rb
@@ -1,5 +1,5 @@
 module Yara
   class UserData < FFI::Struct
-    layout :number, :int32
+    layout :number, :int
   end
 end

--- a/lib/yara/yr_meta.rb
+++ b/lib/yara/yr_meta.rb
@@ -3,8 +3,8 @@ module Yara
     layout \
       :identifier, :string,
       :string, :string,
-      :integer, :int64_t,
-      :type, :int32_t,
-      :flags, :int32_t
+      :integer, :ulong_long,
+      :type, :int,
+      :flags, :int
   end
 end

--- a/lib/yara/yr_rule.rb
+++ b/lib/yara/yr_rule.rb
@@ -1,7 +1,7 @@
 module Yara
   class YrRule < FFI::Struct
     layout \
-      :flags, :int32_t,
+      :flags, :int,
       :identifier, :string,
       :tags, :string,
       :metas, :pointer,

--- a/lib/yara/yr_string.rb
+++ b/lib/yara/yr_string.rb
@@ -1,15 +1,15 @@
 module Yara
   class YrString < FFI::Struct
     layout \
-      :flags, :uint32_t,
-      :idx, :uint32_t,
-      :fixed_offset, :int64_t,
-      :rule_idx, :uint32_t,
-      :length, :int32_t,
+      :flags, :uint,
+      :idx, :uint,
+      :fixed_offset, :ulong_long,
+      :rule_idx, :uint,
+      :length, :uint,
       :string, :pointer,
       :chained_to, :pointer,
-      :chain_gap_min, :int32_t,
-      :chain_gap_max, :int32_t,
+      :chain_gap_min, :uint,
+      :chain_gap_max, :uint,
       :identifier, :string
   end
 end


### PR DESCRIPTION
For reasons that I don't really understand, the FFI gem under linux with an Arm architecture (specifically, trying to run in a Docker linux image on Apple Silicon) has problems with recognizing certain types -- specifically integer types that specify bit width (for example `int32_t`).  But, for all the architectures the FFI gem supports, these all collapse to `int` or `long` types. I converted all the of the numeric Yara fields to `:int`, `:uint`, or `:ulong_long` as appropriate. This now runs under Docker on an M1 computer.

One note: something changed the yara-ffi spec to `3.0.0`; I don't know if that's what you'd want. There probably should be a version change though.