### PR TITLE
Bump version number to 3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux

--- a/lib/yara/version.rb
+++ b/lib/yara/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Yara
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Bump version to reflect https://github.com/jonmagic/yara-ffi/pull/20 and https://github.com/jonmagic/yara-ffi/pull/21 being merged. Will release new version to rubygems.org.